### PR TITLE
Collect anonymous usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The available configuration options are detailed in [our documentation](https://
 | JUMPWIRE_SSO_SIGNED_ENVELOPES | true | Whether to expect the SSO IdP to sign its SAML envelopes. |
 | JUMPWIRE_SSO_GENERATED_CERTNAME | localhost | Name of ACME generated TLS certificate to use with SSO requests. Not used if a TLS cert and key are explicitly configured. |
 | JUMPWIRE_SSO_GROUPS_ATTRIBUTE | Group | Attribute on SAML assertions listing the groups a user is a member of. |
+| JUMPWIRE_DISABLE_REPORTING | false | Disable reporting of anonymous usage analytics. |
 
 ### Encryption keys
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -92,7 +92,9 @@ config :hydrax, JumpWire.Cloak.Storage.DeltaCrdt.DiskStorage, filename: 'jumpwir
 
 config :telemetry_metrics_prometheus, port: 9568
 
-config :jumpwire, :metadata, org_id: "org_generic"
+config :jumpwire, :metadata,
+  org_id: "org_generic",
+  node_id: nil
 
 config :samly, Samly.State, store: JumpWire.SSO.SamlyState
 config :samly, Samly.Provider, idp_id_from: :path_segment
@@ -105,9 +107,16 @@ config :jumpwire, :acme,
   generate: false,
   key_size: 4096,
   directory_url: "https://acme-staging-v02.api.letsencrypt.org/directory",
-  cert_renewal_seconds: 60 * 60 * 24 * 30,  # 30 days
+  # default to 30 days
+  cert_renewal_seconds: 60 * 60 * 24 * 30,
   cert_dir: "priv/pki",
   hostname: nil,
   email: nil
+
+config :jumpwire, JumpWire.Analytics,
+  enabled: false,
+  api_url: "https://events.jumpwire.io",
+  api_key: "phc_GxUkxISBf1whq6dhJ3Ucb7hlPh7OqExJm8qSQqxhhCE",
+  timeout: 5_000
 
 import_config "#{config_env()}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -15,3 +15,5 @@ config :honeybadger, environment_name: :ignored
 
 config :jumpwire, :acme,
   directory_url: "https://acme-v02.api.letsencrypt.org/directory"
+
+config :jumpwire, JumpWire.Analytics, enabled: true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -328,3 +328,8 @@ with {:ok, path} <- System.fetch_env("JUMPWIRE_SSO_METADATA_PATH"),
       }
     ]
 end
+
+with {:ok, val} <- fetch_boolean_env("JUMPWIRE_DISABLE_REPORTING") do
+  config :jumpwire, JumpWire.Analytics,
+    enabled: not val
+end

--- a/lib/jumpwire/analytics.ex
+++ b/lib/jumpwire/analytics.ex
@@ -1,0 +1,108 @@
+defmodule JumpWire.Analytics do
+  @moduledoc """
+  Capture and report anonymized information about product usage.
+  """
+
+  require Logger
+
+  def capture(event, properties) do
+    opts = Application.get_env(:jumpwire, __MODULE__)
+
+    if opts[:enabled] do
+      Task.Supervisor.async_nolink(JumpWire.AnalyticsSupervisor, fn -> capture(event, properties, opts) end)
+    end
+  end
+
+  defp capture(event, properties, opts) do
+    node_info =
+      case JumpWire.node_info() do
+        {:ok, info} -> info
+        _ -> %{}
+      end
+
+    version = Map.get(node_info, :version, "unknown")
+    user_agent = "jumpwire-#{version}"
+    id = JumpWire.Metadata.get_node_id()
+
+    cpu =
+      case :erlang.system_info(:logical_processors) do
+        :uknown -> 0
+        count -> count
+      end
+
+    node_properties = %{
+      "version" => version,
+      "arch" => :erlang.system_info(:system_architecture) |> to_string(),
+      "cpu_count" => cpu,
+    }
+
+    client = Tesla.client([
+      Tesla.Middleware.JSON,
+      Tesla.Middleware.FollowRedirects,
+      {Tesla.Middleware.Headers, [{"user-agent", user_agent}]},
+      {Tesla.Middleware.BaseUrl, opts[:api_url]},
+      {Tesla.Middleware.Timeout, timeout: opts[:timeout]},
+      {Tesla.Middleware.Retry, [
+          delay: 500,
+          should_retry: fn
+            {:ok, %{status: 200}} -> false
+            _ -> true
+          end
+        ]
+      },
+    ])
+
+    body = %{
+      "api_key" => opts[:api_key],
+      "distinct_id" => id,
+      "event" => event,
+      "properties" => properties,
+      "$set" => node_properties,
+    }
+
+    case Tesla.post(client, "/capture", body) do
+      {:ok, %{status: 200}} -> Logger.debug("Sent '#{event}' event")
+      err -> Logger.debug("Failed to report '#{event}' event: #{inspect err}")
+    end
+  end
+
+  @doc """
+  Report that the system has successfully loaded its configuration.
+  """
+  def config_loaded(_org_id, data) do
+    client_count = Map.get(data, :client_auth, []) |> Enum.count()
+    group_count = Map.get(data, :groups, []) |> Enum.count()
+    manifests = Map.get(data, :manifests, [])
+    pg_count = manifests |> Stream.filter(fn m -> m.root_type == :postgresql end) |> Enum.count()
+    mysql_count = manifests |> Stream.filter(fn m -> m.root_type == :mysql end) |> Enum.count()
+    metastore_count = Map.get(data, :metastores, []) |> Enum.count()
+    policy_count = Map.get(data, :policies, []) |> Enum.count()
+    schemas = Map.get(data, :proxy_schemas, [])
+    schema_count = Enum.count(schemas)
+    label_count = schemas
+    |> Stream.map(fn s -> s.fields end)
+    |> Stream.flat_map(fn f -> Map.values(f) end)
+    |> Stream.uniq()
+    |> Enum.count()
+
+    properties = %{
+      "clients" => client_count,
+      "groups" => group_count,
+      "postgresql_manifests" => pg_count,
+      "mysql_manifests" => mysql_count,
+      "metastores" => metastore_count,
+      "policies" => policy_count,
+      "schemas" => schema_count,
+      "labels" => label_count,
+    }
+    capture("loaded", properties)
+  end
+
+  @doc """
+  Report that a client has connected and authenticated to the proxy.
+  """
+  def proxy_authenticated(_org_id, db_type) do
+    properties = %{"database" => to_string(db_type)}
+    capture("client.authenticated", properties)
+  end
+end

--- a/lib/jumpwire/application.ex
+++ b/lib/jumpwire/application.ex
@@ -85,6 +85,8 @@ defmodule JumpWire.Application do
 
   @impl true
   def start(_type, _args) do
+    JumpWire.Metadata.set_node_id()
+
     # Register default ports for websocket schemes, used when parsing
     # a string into a URI structure.
     URI.default_port("ws", 80)
@@ -159,6 +161,7 @@ defmodule JumpWire.Application do
       {Task.Supervisor, name: JumpWire.ProxySupervisor},
       {Task.Supervisor, name: JumpWire.DatabaseConnectionSupervisor},
       {Task.Supervisor, name: JumpWire.ACMESupervisor},
+      {Task.Supervisor, name: JumpWire.AnalyticsSupervisor},
 
       {Phoenix.PubSub, name: JumpWire.PubSub.server()},
       JumpWire.LocalConfig,

--- a/lib/jumpwire/config_loader.ex
+++ b/lib/jumpwire/config_loader.ex
@@ -62,7 +62,11 @@ defmodule JumpWire.ConfigLoader do
   @doc """
   Load objects from all configured stores.
   """
-  def load(org_id), do: from_disk(org_id)
+  def load(org_id) do
+    data = from_disk(org_id)
+    JumpWire.Analytics.config_loaded(org_id, data)
+    data
+  end
 
   @doc """
   Load configuration objects from YAML files located in a specified directory.

--- a/lib/jumpwire/metadata.ex
+++ b/lib/jumpwire/metadata.ex
@@ -21,4 +21,13 @@ defmodule JumpWire.Metadata do
     Uniq.UUID.uuid5(:oid, "urn:jumpwire.io:organization:#{org_id}")
   end
   def org_id_to_uuid(org_id), do: org_id
+
+  def set_node_id() do
+    id = Uniq.UUID.uuid4()
+    JumpWire.update_env(:metadata, :node_id, id)
+  end
+
+  def get_node_id() do
+    Application.get_env(:jumpwire, :metadata)[:node_id]
+  end
 end

--- a/lib/jumpwire/proxy/database.ex
+++ b/lib/jumpwire/proxy/database.ex
@@ -113,6 +113,7 @@ defmodule JumpWire.Proxy.Database do
         with {:ok, %{root_type: unquote(manifest_type)}} <- JumpWire.Manifest.fetch(org_id, db_id),
              {:ok, state} <- client_authenticated(client, org_id, db_id, state) do
           Logger.debug("Client authenticated")
+          JumpWire.Analytics.proxy_authenticated(org_id, unquote(manifest_type))
           {:noreply, state}
         else
           _ ->

--- a/lib/jumpwire/proxy/mysql.ex
+++ b/lib/jumpwire/proxy/mysql.ex
@@ -367,6 +367,7 @@ defmodule JumpWire.Proxy.MySQL do
          {:ok, db} <- JumpWire.GlobalConfig.fetch(:manifests, {org_id, db_id}) do
       JumpWire.Tracer.context(org_id: org_id, manifest: db_id, client: client_id)
       Logger.info("Client successfully authenticated")
+      JumpWire.Analytics.proxy_authenticated(org_id, :mysql)
       Messages.ok_msg() |> encode_and_send(seq, state.client_socket)
 
       state = %{state |

--- a/lib/jumpwire/proxy/postgres.ex
+++ b/lib/jumpwire/proxy/postgres.ex
@@ -260,6 +260,7 @@ defmodule JumpWire.Proxy.Postgres do
            {:ok, state} <- client_authenticated(client, org_id, db_id, state) do
         JumpWire.Tracer.context(client: client_id)
         Logger.debug("Found client for postgresql token")
+        JumpWire.Analytics.proxy_authenticated(org_id, :postgresql)
         state
       else
         _ ->


### PR DESCRIPTION
This starts sending events with anonymous data by default, along with an opt-out flag that disables all reporting. 

Events:
- `loaded` sent right after configuration is loaded. Contains a count of each object type (policies, labels, etc)
- `client.authenticatdd` sent when a client authenticates to the proxy. Contains the proxy type - PostgreSQL or MySQL

Additional metadata collected:
- Number of virtual CPU cores
- OS architecture
- JumpWire version