### PR TITLE
Create a fallback TLS certificate without relying on ACME generation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -54,7 +54,7 @@ config :hydrax, :supervisor,
 config :jumpwire, :proxy,
   secret_key: nil,
   client_ssl: [],
-  server_ssl: [],
+  server_ssl: [use_sni: true],
   parse_requests: true,
   parse_responses: true
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,8 +25,6 @@ config :tesla, :adapter, Tesla.Adapter.Mint
 config :libcluster, :topologies, []
 
 config :jumpwire, JumpWire.Router,
-  enable_http: true,
-  enable_https: true,
   https: [port: 4443],
   http: [port: 4004]
 
@@ -54,7 +52,6 @@ config :hydrax, :supervisor,
   ]
 
 config :jumpwire, :proxy,
-  enable_tls: true,
   secret_key: nil,
   client_ssl: [],
   server_ssl: [],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,9 +12,7 @@ end
 
 
 with {:ok, port} <- System.fetch_env("JUMPWIRE_HTTP_PORT") do
-  config :jumpwire, JumpWire.Router,
-    enable_http: true,
-    http: [port: String.to_integer(port)]
+  config :jumpwire, JumpWire.Router, http: [port: String.to_integer(port)]
 end
 with {:ok, port} <- System.fetch_env("JUMPWIRE_HTTPS_PORT") do
   config :jumpwire, JumpWire.Router, https: [port: String.to_integer(port)]
@@ -23,12 +21,8 @@ end
 with {:ok, cert} <- System.fetch_env("JUMPWIRE_TLS_CERT"),
      {:ok, key} <- System.fetch_env("JUMPWIRE_TLS_KEY") do
   ssl_opts = [certfile: cert, keyfile: key]
-  config :jumpwire, JumpWire.Router,
-    enable_https: true,
-    https: ssl_opts
-  config :jumpwire, :proxy,
-    enable_tls: true,
-    server_ssl: ssl_opts
+  config :jumpwire, JumpWire.Router, https: ssl_opts
+  config :jumpwire, :proxy, server_ssl: ssl_opts
 end
 
 cacert = System.get_env("JUMPWIRE_TLS_CA", CAStore.file_path())

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,7 +20,7 @@ end
 
 with {:ok, cert} <- System.fetch_env("JUMPWIRE_TLS_CERT"),
      {:ok, key} <- System.fetch_env("JUMPWIRE_TLS_KEY") do
-  ssl_opts = [certfile: cert, keyfile: key]
+  ssl_opts = [certfile: cert, keyfile: key, use_sni: false]
   config :jumpwire, JumpWire.Router, https: ssl_opts
   config :jumpwire, :proxy, server_ssl: ssl_opts
 end

--- a/lib/jumpwire/proxy/database.ex
+++ b/lib/jumpwire/proxy/database.ex
@@ -212,7 +212,12 @@ defmodule JumpWire.Proxy.Database do
     |> Map.new()
 
     ssl_opts = proxy_opts[:server_ssl]
-    |> Keyword.put(:sni_fun, &JumpWire.TLS.sni_fun/1)
+    ssl_opts =
+      if ssl_opts[:use_sni] do
+        Keyword.put(ssl_opts, :sni_fun, &JumpWire.TLS.sni_fun/1)
+      else
+        ssl_opts
+      end
 
     state = %{
       client_socket: %Socket{transport: transport, socket: client_socket},

--- a/lib/jumpwire/tls.ex
+++ b/lib/jumpwire/tls.ex
@@ -3,6 +3,8 @@ defmodule JumpWire.TLS do
   Handlers for interacting with cached TLS certificates.
   """
 
+  require Logger
+
   def cached_cert(hostname) when is_binary(hostname) do
     hostname = String.to_charlist(hostname)
     cached_cert(hostname)
@@ -26,6 +28,7 @@ defmodule JumpWire.TLS do
         cert_opts(cert)
 
       _ ->
+        Logger.warn("Missing certificate for #{hostname}, using a self-signed fallback certificate")
         case cached_cert('selfsigned') do
           {:ok, cert} -> cert_opts(cert)
           _ -> []

--- a/test/jumpwire/proxy/postgres_test.exs
+++ b/test/jumpwire/proxy/postgres_test.exs
@@ -134,7 +134,7 @@ defmodule JumpWire.Proxy.PostgresTest do
     end
 
     # update the proxy server to use the SSL cert
-    proxy_opts = Keyword.put(proxy_opts, :server_ssl, [certfile: certfile, keyfile: keyfile, verify_fun: &:ssl_verify_hostname.verify_fun/3])
+    proxy_opts = Keyword.put(proxy_opts, :server_ssl, [certfile: certfile, keyfile: keyfile, verify_fun: &:ssl_verify_hostname.verify_fun/3, use_sni: false])
     Application.put_env(:jumpwire, :proxy, proxy_opts)
 
     # connect with SSL


### PR DESCRIPTION
Fixes #15. 

This lets the proxy server respond to DB clients requesting an SSL connection, even if JumpWire doesn't have any certs configured. Previously there was a static fallback cert but it was only loaded when ACME generation was enabled.