### PR TITLE
add the ability to override sso base url settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The available configuration options are detailed in [our documentation](https://
 | JUMPWIRE_SSO_SIGNED_ENVELOPES | true | Whether to expect the SSO IdP to sign its SAML envelopes. |
 | JUMPWIRE_SSO_GENERATED_CERTNAME | localhost | Name of ACME generated TLS certificate to use with SSO requests. Not used if a TLS cert and key are explicitly configured. |
 | JUMPWIRE_SSO_GROUPS_ATTRIBUTE | Group | Attribute on SAML assertions listing the groups a user is a member of. |
+| JUMPWIRE_SSO_BASE_URL | - | Explicitly set the base URL for SSO requests, including scheme and hostname. This is useful when running the gateway behind a load balancer that terminates TLS, to override the scheme of the host. |
 | JUMPWIRE_DISABLE_REPORTING | false | Disable reporting of anonymous usage analytics. |
 
 ### Encryption keys

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -290,6 +290,7 @@ with {:ok, path} <- System.fetch_env("JUMPWIRE_SSO_METADATA_PATH"),
   sp_id = System.get_env("JUMPWIRE_SSO_SPID", "jumpwire")
   signed_envelopes = get_boolean_env("JUMPWIRE_SSO_SIGNED_ENVELOPES", true)
   generated_name = System.get_env("JUMPWIRE_SSO_GENERATED_CERTNAME", "localhost")
+  sso_base_url = System.get_env("JUMPWIRE_SSO_BASE_URL", "/sso")
 
   config :jumpwire, :sso,
     group_attribute: System.get_env("JUMPWIRE_SSO_GROUPS_ATTRIBUTE", "Group")
@@ -313,7 +314,7 @@ with {:ok, path} <- System.fetch_env("JUMPWIRE_SSO_METADATA_PATH"),
       %{
         id: idp_id,
         sp_id: sp_id,
-        base_url: "/sso",
+        base_url: sso_base_url,
         metadata_file: path,
         sign_requests: true,
         sign_metadata: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -290,7 +290,7 @@ with {:ok, path} <- System.fetch_env("JUMPWIRE_SSO_METADATA_PATH"),
   sp_id = System.get_env("JUMPWIRE_SSO_SPID", "jumpwire")
   signed_envelopes = get_boolean_env("JUMPWIRE_SSO_SIGNED_ENVELOPES", true)
   generated_name = System.get_env("JUMPWIRE_SSO_GENERATED_CERTNAME", "localhost")
-  sso_base_url = System.get_env("JUMPWIRE_SSO_BASE_URL", "/sso")
+  sso_base_url = System.get_env("JUMPWIRE_SSO_BASE_URL", "")
 
   config :jumpwire, :sso,
     group_attribute: System.get_env("JUMPWIRE_SSO_GROUPS_ATTRIBUTE", "Group")
@@ -314,7 +314,7 @@ with {:ok, path} <- System.fetch_env("JUMPWIRE_SSO_METADATA_PATH"),
       %{
         id: idp_id,
         sp_id: sp_id,
-        base_url: sso_base_url,
+        base_url: "#{sso_base_url}/sso",
         metadata_file: path,
         sign_requests: true,
         sign_metadata: true,


### PR DESCRIPTION
In some situations it is necessary to explicitly set the SSO base URL, so that the auth request will contain the correct Assertion Consumer Service URL. Otherwise, there can be a mismatch between the inferred URL and the actual URL.

An example of this is when running behind a load balancer that terminates TLS. In this case the inferred URL will contain `http` instead of `https`