### PR TITLE
Reencode PostgreSQL AST into SQL query

### DIFF
--- a/lib/jumpwire/proxy/postgres/messages.ex
+++ b/lib/jumpwire/proxy/postgres/messages.ex
@@ -108,4 +108,16 @@ defmodule JumpWire.Proxy.Postgres.Messages do
     len = byte_size(body) + 4
     <<len::32, body::binary>>
   end
+
+  def query(:simple, data) do
+    # simple query
+    len = :erlang.iolist_size(data) + 5
+    [<<?Q, len::integer-32>>, data, 0]
+  end
+
+  def query({:parse, name, params}, data) do
+    # prepared statement, also called a Parse message
+    len = :erlang.iolist_size(name) + :erlang.iolist_size(data) + 8
+    [<<?P, len::integer-32>>, name, 0, data, 0, params]
+  end
 end

--- a/lib/jumpwire/proxy/request.ex
+++ b/lib/jumpwire/proxy/request.ex
@@ -13,6 +13,7 @@ defmodule JumpWire.Proxy.Request do
     field :delete, [Field.t()], default: []
     field :insert, [Field.t()], default: []
     field :upstream, JumpWire.Manifest.t(), enforce: false
+    field :source, any(), default: nil
   end
 
   def put_field(request, type, field) do

--- a/lib/jumpwire/proxy/sql/parser.ex
+++ b/lib/jumpwire/proxy/sql/parser.ex
@@ -66,6 +66,7 @@ defmodule JumpWire.Proxy.SQL.Parser do
 
   def parse_postgresql(_query), do: :erlang.nif_error(:nif_not_loaded)
   def debug_parse(_query, _dialect), do: :erlang.nif_error(:nif_not_loaded)
+  def to_sql(_query), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
   In PostgreSQL, system tables names always being with `pg_`. Unqualified references will

--- a/lib/jumpwire/proxy/sql/statement.ex
+++ b/lib/jumpwire/proxy/sql/statement.ex
@@ -119,6 +119,7 @@ defmodule JumpWire.Proxy.SQL.Statement do
     field :args, [Statement.function_arg()] | nil
     field :with_hints, [Statement.expr()]
     field :version, Statement.table_version() | nil
+    field :partitions, [Statement.Ident.t()]
   end
 
   @type table_version() :: {:for_system_time_as_of, expr()}

--- a/lib/jumpwire/record.ex
+++ b/lib/jumpwire/record.ex
@@ -11,6 +11,7 @@ defmodule JumpWire.Record do
   typed_embedded_schema null: false, enforce: true do
     field :data, Ecto.Any
     field :source, :string
+    field :source_data, Ecto.Any, enforce: false
     field :labels, {:map, {:array, :string}}, default: %{}
     field :label_format, Ecto.Enum, values: [:jsonp, :key], default: :jsonp
     field :policies, {:map, {:array, :string}}, default: %{}


### PR DESCRIPTION
This will keep a reference to the parsed AST in the NIF as an Arc, allocated by the BEAM and tracked as a ref. The ref is tracked as a field on the Request struct in the proxy module.

Once query policies are applied, the AST is serialized back into a SQL binary and that binary is sent to the upstream DB instead of the original data.

This will make it possible to change the query by modifying the AST (in the NIF) in the future.