### PR TITLE
Policy to add a filter to all SQL selections

### DIFF
--- a/lib/jumpwire/policy/filter_request.ex
+++ b/lib/jumpwire/policy/filter_request.ex
@@ -1,0 +1,46 @@
+defmodule JumpWire.Policy.FilterRequest do
+  @moduledoc """
+  Add a filter to each matching request.
+  """
+
+  use JumpWire.Schema
+  import Ecto.Changeset
+  alias JumpWire.Proxy.SQL.Parser
+  require Logger
+
+  @behaviour JumpWire.Policy
+
+  @primary_key false
+  typed_embedded_schema null: false do
+    field :type, Ecto.Atom, default: :filter_request
+    field :table, :string
+    field :field, :string
+    field :source, Ecto.Enum, values: [:user_id], default: :user_id
+  end
+
+  @doc false
+  def changeset(config, attrs) do
+    config
+    |> cast(attrs, [:type, :table, :field, :source])
+    |> validate_required([:table, :field, :source])
+  end
+
+  @impl true
+  def handle(record = %{source_data: ref}, _, policy, request) when is_reference(ref) do
+    opts = policy.configuration
+
+    with :user_id <- opts.source,
+         {:ok, %{"jw_id" => id}} when is_binary(id) <- Map.fetch(request, :params) do
+      case Parser.add_table_selection(ref, opts.table, opts.field, :eq, id) do
+        :ok -> {:cont, record}
+        err ->
+          Logger.error("Unable to add filter to SQL request: #{inspect err}")
+          {:halt, {:error, :sql_failure}}
+      end
+    else
+      _ -> {:halt, {:error, :missing_sql_id}}
+    end
+  end
+
+  def handle(record, _, _, _), do: {:cont, record}
+end

--- a/lib/jumpwire/proxy/database.ex
+++ b/lib/jumpwire/proxy/database.ex
@@ -299,6 +299,7 @@ defmodule JumpWire.Proxy.Database do
       type: :db_proxy,
       classification: client.classification,
       attributes: attributes,
+      params: state.startup_params,
     })
 
     JumpWire.Policy.apply_policies(policies, record, info)

--- a/lib/jumpwire/proxy/database.ex
+++ b/lib/jumpwire/proxy/database.ex
@@ -355,4 +355,17 @@ defmodule JumpWire.Proxy.Database do
 
     put_tables(org_id, db_id, tables, schemas)
   end
+
+  @doc """
+  Sanitize a string being passed in as part of the connection params.
+  """
+  def sanitize_id(id) do
+    if String.contains?(id, "'") do
+      updated = String.replace(id, "'", "")
+      Logger.warning("Invalid value passed as connection parameter: #{inspect id}. The value will be updated to #{inspect updated}")
+      updated
+    else
+      id
+    end
+  end
 end

--- a/lib/jumpwire/proxy/postgres.ex
+++ b/lib/jumpwire/proxy/postgres.ex
@@ -402,6 +402,14 @@ defmodule JumpWire.Proxy.Postgres do
     |> Stream.map(fn [key, _, value, _] ->
       {:binary.list_to_bin(key), :binary.list_to_bin(value)}
     end)
+    |> Stream.flat_map(fn
+      {"user", value} ->
+        case String.split(value, "#", parts: 2) do
+          [user, jw_id] -> [{"user", user}, {"jw_id", jw_id}]
+          _ -> [{"user", value}]
+        end
+      x -> [x]
+    end)
     |> Map.new()
   end
 

--- a/lib/jumpwire/proxy/postgres.ex
+++ b/lib/jumpwire/proxy/postgres.ex
@@ -405,7 +405,9 @@ defmodule JumpWire.Proxy.Postgres do
     |> Stream.flat_map(fn
       {"user", value} ->
         case String.split(value, "#", parts: 2) do
-          [user, jw_id] -> [{"user", user}, {"jw_id", jw_id}]
+          [user, jw_id] ->
+            [{"user", user}, {"jw_id", Database.sanitize_id(jw_id)}]
+
           _ -> [{"user", value}]
         end
       x -> [x]

--- a/lib/jumpwire/proxy/postgres/messages.ex
+++ b/lib/jumpwire/proxy/postgres/messages.ex
@@ -98,6 +98,9 @@ defmodule JumpWire.Proxy.Postgres.Messages do
   end
 
   def startup_message(params) do
+    # Filter out any params that are JumpWire specific
+    params = params |> Stream.reject(fn {key, _} -> String.starts_with?(key, "jw_") end)
+
     version = <<196_608::32>>
     body = params
     |> Stream.map(fn {key, value} ->

--- a/lib/jumpwire/proxy/sql/parser.ex
+++ b/lib/jumpwire/proxy/sql/parser.ex
@@ -67,6 +67,7 @@ defmodule JumpWire.Proxy.SQL.Parser do
   def parse_postgresql(_query), do: :erlang.nif_error(:nif_not_loaded)
   def debug_parse(_query, _dialect), do: :erlang.nif_error(:nif_not_loaded)
   def to_sql(_query), do: :erlang.nif_error(:nif_not_loaded)
+  def add_table_selection(_ref, _table, _left, _op, _right), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
   In PostgreSQL, system tables names always being with `pg_`. Unqualified references will

--- a/lib/jumpwire/proxy/sql/statement.ex
+++ b/lib/jumpwire/proxy/sql/statement.ex
@@ -202,7 +202,7 @@ defmodule JumpWire.Proxy.SQL.Statement do
   typedstruct module: OrderByExpr do
     field :expr, Statment.expr()
     field :asc, boolean()
-    field :nulls_first, boolean()
+    field :nulls_first, boolean() | nil
   end
 
   typedstruct module: Offset do

--- a/lib/jumpwire/proxy/sql/statement.ex
+++ b/lib/jumpwire/proxy/sql/statement.ex
@@ -710,6 +710,51 @@ defmodule JumpWire.Proxy.SQL.Statement do
     field :opt_search_modifier, Statement.search_modifier() | nil
   end
 
+  @type copy_target() :: :stdin | :stdout | %{filename: String.t()} | %{command: String.t()}
+  @type copy_option()
+  :: {:format, Ident.t()}
+  | {:freeze, boolean()}
+  | {:delimiter, char()}
+  | {:null, String.t}
+  | {:header, boolean()}
+  | {:quote, char()}
+  | {:escape, char()}
+  | {:force_quote, [Ident.t()]}
+  | {:force_not_null, [Ident.t()]}
+  | {:force_null, [Ident.t()]}
+  | {:encoding, String.t()}
+  @type copy_legacy_option() :: :binary | {:delimiter, char()} | {:null, String.t()} | {:csv, [copy_legacy_csv_option()]}
+  @type copy_legacy_csv_option()
+  :: :header
+  | {:quote, char()}
+  | {:escape, char()}
+  | {:force_quote, [Ident.t()]}
+  | {:force_not_null, [Ident.t()]}
+
+  typedstruct module: Copy do
+    field :source, %{table_name: Statement.object_name(), columns: [Statement.Ident.t()]} | Statement.Query.t()
+    field :to, boolean()
+    field :target, Statement.copy_target()
+    field :options, [Statement.copy_option()]
+    field :legacy_options, [Statement.copy_legacy_csv_option()]
+    field :values, [String.t() | nil]
+  end
+
+  typedstruct module: SqlOption do
+    field :name, Statement.Ident.t()
+    field :value, Statement.value()
+  end
+
+  typedstruct module: CreateView do
+    field :or_replace, boolean()
+    field :materialized, boolean()
+    field :name, Statement.object_name()
+    field :columns, Statement.Ident.t()
+    field :query, Statement.Query.t()
+    field :with_options, [Statement.SqlOption.t()]
+    field :cluster_by, [Statement.Ident.t()]
+  end
+
   @type expr()
   :: Ident.t
   | {:compound_identifier, [Ident.t]}

--- a/native/jumpwire_proxy_sql_parser/Cargo.lock
+++ b/native/jumpwire_proxy_sql_parser/Cargo.lock
@@ -169,6 +169,18 @@ checksum = "0272b7bb0a225320170c99901b4b5fb3a4384e255a7f2cc228f61e2ba3893e75"
 dependencies = [
  "log",
  "serde",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55fe75cb4a364c7f7ae06c7dbbc8d84bddd85d6cdf9975963c3935bc1991761e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/native/jumpwire_proxy_sql_parser/Cargo.toml
+++ b/native/jumpwire_proxy_sql_parser/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.27.0"
-sqlparser = { version = "0.38.0", features = ["serde"] }
+sqlparser = { version = "0.38.0", features = ["serde", "visitor"] }
 serde = "1.0"
 serde_rustler = { git = "https://github.com/jumpwire-ai/serde_rustler" }

--- a/native/jumpwire_proxy_sql_parser/src/filter.rs
+++ b/native/jumpwire_proxy_sql_parser/src/filter.rs
@@ -1,0 +1,3 @@
+mod table;
+
+pub use self::table::TableFilterVisit;

--- a/native/jumpwire_proxy_sql_parser/src/filter/table.rs
+++ b/native/jumpwire_proxy_sql_parser/src/filter/table.rs
@@ -1,0 +1,575 @@
+use crate::matcher::TableMatch;
+use sqlparser::ast::{
+    Assignment, BinaryOperator, CopySource, Cte, Expr, Function, FunctionArg, FunctionArgExpr,
+    GroupByExpr, Join, ListAggOnOverflow, OnConflictAction, OnInsert, OrderByExpr, Query, Select,
+    SelectItem, SetExpr, Statement, TableFactor, TableWithJoins, WildcardAdditionalOptions,
+    WindowType, With,
+};
+
+/// Trait to recusrively visit all elements of a query looking for a
+/// particular table. When the table is found, a filter expression will
+/// be added to it. For example, `SELECT * FROM foo` becomes
+/// `SELECT * FROM foo WHERE id = 'abc'`
+pub trait TableFilterVisit {
+    fn visit(&mut self, _: &Vec<String>, _: &Expr) -> ();
+}
+
+impl TableFilterVisit for Expr {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match *self {
+            Expr::JsonAccess {
+                ref mut left,
+                ref mut right,
+                ..
+            } => {
+                left.visit(table, clause);
+                right.visit(table, clause)
+            }
+            Expr::CompositeAccess { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::IsFalse(ref mut expr) => expr.visit(table, clause),
+            Expr::IsNotFalse(ref mut expr) => expr.visit(table, clause),
+            Expr::IsTrue(ref mut expr) => expr.visit(table, clause),
+            Expr::IsNotTrue(ref mut expr) => expr.visit(table, clause),
+            Expr::IsNull(ref mut expr) => expr.visit(table, clause),
+            Expr::IsNotNull(ref mut expr) => expr.visit(table, clause),
+            Expr::IsUnknown(ref mut expr) => expr.visit(table, clause),
+            Expr::IsNotUnknown(ref mut expr) => expr.visit(table, clause),
+            Expr::IsDistinctFrom(ref mut left, ref mut right) => {
+                left.visit(table, clause);
+                right.visit(table, clause)
+            }
+            Expr::IsNotDistinctFrom(ref mut left, ref mut right) => {
+                left.visit(table, clause);
+                right.visit(table, clause)
+            }
+            Expr::InList {
+                ref mut expr,
+                ref mut list,
+                ..
+            } => {
+                expr.visit(table, clause);
+                list.visit(table, clause)
+            }
+            Expr::InSubquery {
+                ref mut expr,
+                ref mut subquery,
+                ..
+            } => {
+                expr.visit(table, clause);
+                subquery.visit(table, clause)
+            }
+            Expr::InUnnest {
+                ref mut expr,
+                ref mut array_expr,
+                ..
+            } => {
+                expr.visit(table, clause);
+                array_expr.visit(table, clause)
+            }
+            Expr::Between {
+                ref mut expr,
+                ref mut low,
+                ref mut high,
+                ..
+            } => {
+                expr.visit(table, clause);
+                low.visit(table, clause);
+                high.visit(table, clause)
+            }
+            Expr::BinaryOp {
+                ref mut left,
+                ref mut right,
+                ..
+            } => {
+                left.visit(table, clause);
+                right.visit(table, clause)
+            }
+            Expr::Like {
+                ref mut expr,
+                ref mut pattern,
+                ..
+            } => {
+                expr.visit(table, clause);
+                pattern.visit(table, clause)
+            }
+            Expr::ILike {
+                ref mut expr,
+                ref mut pattern,
+                ..
+            } => {
+                expr.visit(table, clause);
+                pattern.visit(table, clause)
+            }
+            Expr::SimilarTo {
+                ref mut expr,
+                ref mut pattern,
+                ..
+            } => {
+                expr.visit(table, clause);
+                pattern.visit(table, clause)
+            }
+            Expr::AnyOp {
+                ref mut left,
+                ref mut right,
+                ..
+            } => {
+                left.visit(table, clause);
+                right.visit(table, clause)
+            }
+            Expr::AllOp {
+                ref mut left,
+                ref mut right,
+                ..
+            } => {
+                left.visit(table, clause);
+                right.visit(table, clause)
+            }
+            Expr::UnaryOp { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::Cast { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::TryCast { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::SafeCast { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::AtTimeZone {
+                ref mut timestamp, ..
+            } => timestamp.visit(table, clause),
+            Expr::Extract { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::Ceil { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::Floor { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::Position {
+                ref mut expr,
+                ref mut r#in,
+            } => {
+                expr.visit(table, clause);
+                r#in.visit(table, clause)
+            }
+            Expr::Substring {
+                ref mut expr,
+                ref mut substring_from,
+                ref mut substring_for,
+                ..
+            } => {
+                substring_from.visit(table, clause);
+                substring_for.visit(table, clause);
+                expr.visit(table, clause)
+            }
+            Expr::Trim {
+                ref mut expr,
+                ref mut trim_what,
+                ..
+            } => {
+                trim_what.visit(table, clause);
+                expr.visit(table, clause)
+            }
+            Expr::Overlay {
+                ref mut expr,
+                ref mut overlay_what,
+                ref mut overlay_from,
+                ref mut overlay_for,
+                ..
+            } => {
+                overlay_for.visit(table, clause);
+                overlay_from.visit(table, clause);
+                overlay_what.visit(table, clause);
+                expr.visit(table, clause)
+            }
+            Expr::Collate { ref mut expr, .. } => expr.visit(table, clause),
+            Expr::Nested(ref mut expr) => expr.visit(table, clause),
+            Expr::MapAccess {
+                ref mut column,
+                ref mut keys,
+                ..
+            } => {
+                column.visit(table, clause);
+                keys.visit(table, clause)
+            }
+            Expr::AggregateExpressionWithFilter {
+                ref mut expr,
+                ref mut filter,
+            } => {
+                expr.visit(table, clause);
+                filter.visit(table, clause)
+            }
+            Expr::Case {
+                ref mut operand,
+                ref mut conditions,
+                ref mut results,
+                ref mut else_result,
+                ..
+            } => {
+                operand.visit(table, clause);
+                conditions.visit(table, clause);
+                results.visit(table, clause);
+                else_result.visit(table, clause)
+            }
+            Expr::Exists {
+                ref mut subquery, ..
+            } => subquery.visit(table, clause),
+            Expr::Subquery(ref mut query) => query.visit(table, clause),
+            Expr::ArraySubquery(ref mut query) => query.visit(table, clause),
+            Expr::ListAgg(ref mut agg) => {
+                agg.expr.visit(table, clause);
+                agg.separator.visit(table, clause);
+                agg.on_overflow.as_mut().map(|overflow| {
+                    if let ListAggOnOverflow::Truncate { filler, .. } = overflow {
+                        filler.visit(table, clause);
+                    }
+                });
+                for group in agg.within_group.iter_mut() {
+                    group.expr.visit(table, clause);
+                }
+            }
+            Expr::ArrayAgg(ref mut agg) => {
+                agg.expr.visit(table, clause);
+                agg.limit.visit(table, clause);
+                agg.order_by.as_mut().map(|order| {
+                    for o in order.iter_mut() {
+                        o.expr.visit(table, clause);
+                    }
+                });
+            }
+            Expr::GroupingSets(ref mut exprs) => exprs.visit(table, clause),
+            Expr::Cube(ref mut exprs) => exprs.visit(table, clause),
+            Expr::Rollup(ref mut exprs) => exprs.visit(table, clause),
+            Expr::Tuple(ref mut exprs) => exprs.visit(table, clause),
+            Expr::ArrayIndex {
+                ref mut obj,
+                ref mut indexes,
+            } => {
+                obj.visit(table, clause);
+                indexes.visit(table, clause)
+            }
+            Expr::Array(ref mut array) => array.elem.visit(table, clause),
+            Expr::Interval(ref mut int) => int.value.visit(table, clause),
+            Expr::Function(ref mut func) => func.visit(table, clause),
+            _ => (),
+        }
+    }
+}
+
+impl TableFilterVisit for Statement {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match *self {
+            Statement::Query(ref mut query) => query.visit(table, clause),
+            Statement::Insert {
+                ref mut source,
+                ref mut partitioned,
+                ref mut on,
+                ref mut returning,
+                ..
+            } => {
+                source.visit(table, clause);
+                partitioned.visit(table, clause);
+                on.visit(table, clause);
+                returning.visit(table, clause)
+            }
+            Statement::Copy { ref mut source, .. } => source.visit(table, clause),
+            Statement::Update {
+                table: ref mut update_table,
+                ref mut assignments,
+                ref mut from,
+                ref mut selection,
+                ref mut returning,
+            } => {
+                assignments.visit(table, clause);
+                returning.visit(table, clause);
+                update_table.visit(table, clause);
+                from.visit(table, clause);
+
+                if update_table.matches(table) || from.matches(table) {
+                    let updated = match selection {
+                        None => Some(clause.clone()),
+                        Some(existing) => Some(Expr::BinaryOp {
+                            op: BinaryOperator::And,
+                            left: Box::new(existing.clone()),
+                            right: Box::new(clause.clone()),
+                        }),
+                    };
+                    *selection = updated;
+                }
+
+                selection.visit(table, clause)
+            }
+            Statement::Delete {
+                ref tables,
+                ref mut from,
+                ref mut using,
+                ref mut selection,
+                ref mut returning,
+            } => {
+                returning.visit(table, clause);
+                from.visit(table, clause);
+                using.visit(table, clause);
+
+                if tables.matches(table) || from.matches(table) || using.matches(table) {
+                    let updated = match selection {
+                        None => Some(clause.clone()),
+                        Some(existing) => Some(Expr::BinaryOp {
+                            op: BinaryOperator::And,
+                            left: Box::new(existing.clone()),
+                            right: Box::new(clause.clone()),
+                        }),
+                    };
+                    *selection = updated;
+                }
+
+                selection.visit(table, clause)
+            }
+            Statement::CreateView { ref mut query, .. } => query.visit(table, clause),
+            _ => (),
+        }
+    }
+}
+
+impl TableFilterVisit for Function {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        self.args.visit(table, clause);
+        self.over.visit(table, clause);
+        self.order_by.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for FunctionArg {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        let expr = match *self {
+            FunctionArg::Named {
+                name: _,
+                ref mut arg,
+            } => arg,
+            FunctionArg::Unnamed(ref mut arg) => arg,
+        };
+
+        if let FunctionArgExpr::Expr(ref mut expr) = expr {
+            expr.visit(table, clause)
+        }
+    }
+}
+
+impl TableFilterVisit for WindowType {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        if let WindowType::WindowSpec(ref mut spec) = *self {
+            spec.partition_by.visit(table, clause);
+            spec.order_by.visit(table, clause)
+        }
+    }
+}
+
+impl TableFilterVisit for OrderByExpr {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        self.expr.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for OnInsert {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match *self {
+            OnInsert::DuplicateKeyUpdate(ref mut assignments) => {
+                for a in assignments.iter_mut() {
+                    a.visit(table, clause);
+                }
+            }
+            OnInsert::OnConflict(ref mut conflict) => {
+                if let OnConflictAction::DoUpdate(ref mut update) = conflict.action {
+                    update.selection.visit(table, clause);
+                    update.assignments.visit(table, clause)
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+impl TableFilterVisit for SelectItem {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match *self {
+            SelectItem::UnnamedExpr(ref mut expr) => expr.visit(table, clause),
+            SelectItem::ExprWithAlias {
+                ref mut expr,
+                alias: _,
+            } => expr.visit(table, clause),
+            _ => (),
+        }
+    }
+}
+
+impl TableFilterVisit for Assignment {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        self.value.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for SetExpr {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match *self {
+            SetExpr::Select(ref mut select) => select.visit(table, clause),
+            SetExpr::Query(ref mut query) => query.visit(table, clause),
+            SetExpr::Insert(ref mut statement) => statement.visit(table, clause),
+            SetExpr::Update(ref mut statement) => statement.visit(table, clause),
+            SetExpr::SetOperation {
+                ref mut left,
+                ref mut right,
+                ..
+            } => {
+                left.visit(table, clause);
+                right.visit(table, clause)
+            }
+            _ => (),
+        }
+    }
+}
+
+impl TableFilterVisit for Select {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        if self.matches(table) {
+            self.selection = match &self.selection {
+                None => Some(clause.clone()),
+                Some(existing) => Some(Expr::BinaryOp {
+                    op: BinaryOperator::And,
+                    left: Box::new(existing.clone()),
+                    right: Box::new(clause.clone()),
+                }),
+            };
+        }
+
+        self.from.visit(table, clause);
+        self.selection.visit(table, clause);
+        self.projection.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for Query {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        self.with.visit(table, clause);
+        self.order_by.visit(table, clause);
+        self.limit.visit(table, clause);
+        self.body.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for With {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        self.cte_tables.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for Cte {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        self.query.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for TableWithJoins {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        for join in self.joins.iter_mut() {
+            join.visit(table, clause)
+        }
+        self.relation.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for Join {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        self.relation.visit(table, clause)
+    }
+}
+
+impl TableFilterVisit for TableFactor {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match self {
+            TableFactor::Table { with_hints, .. } => with_hints.visit(table, clause),
+            TableFactor::Derived { subquery, .. } => subquery.visit(table, clause),
+            TableFactor::TableFunction { expr, alias: _ } => expr.visit(table, clause),
+            TableFactor::UNNEST { array_exprs, .. } => array_exprs.visit(table, clause),
+            TableFactor::NestedJoin {
+                table_with_joins,
+                alias: _,
+            } => table_with_joins.visit(table, clause),
+            TableFactor::Pivot {
+                aggregate_function, ..
+            } => aggregate_function.visit(table, clause),
+        }
+    }
+}
+
+impl TableFilterVisit for CopySource {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match *self {
+            CopySource::Table {
+                ref table_name,
+                ref columns,
+            } => {
+                if table_name.matches(table) {
+                    let table = TableWithJoins {
+                        relation: TableFactor::Table {
+                            name: table_name.clone(),
+                            alias: None,
+                            args: None,
+                            with_hints: vec![],
+                            version: None,
+                            partitions: vec![],
+                        },
+                        joins: vec![],
+                    };
+                    let projection = if columns.is_empty() {
+                        vec![SelectItem::Wildcard(WildcardAdditionalOptions::default())]
+                    } else {
+                        columns
+                            .iter()
+                            .map(|c| SelectItem::UnnamedExpr(Expr::Identifier(c.clone())))
+                            .collect()
+                    };
+                    let select = Select {
+                        distinct: None,
+                        top: None,
+                        projection,
+                        into: None,
+                        from: vec![table],
+                        lateral_views: vec![],
+                        selection: Some(clause.clone()),
+                        group_by: GroupByExpr::Expressions(vec![]),
+                        cluster_by: vec![],
+                        distribute_by: vec![],
+                        sort_by: vec![],
+                        having: None,
+                        named_window: vec![],
+                        qualify: None,
+                    };
+                    let body = SetExpr::Select(Box::new(select));
+                    let query = Query {
+                        with: None,
+                        body: Box::new(body),
+                        order_by: vec![],
+                        limit: None,
+                        offset: None,
+                        fetch: None,
+                        locks: vec![],
+                    };
+                    *self = CopySource::Query(Box::new(query));
+                    ()
+                }
+            }
+            CopySource::Query(ref mut query) => query.visit(table, clause),
+        }
+    }
+}
+
+impl<T: TableFilterVisit> TableFilterVisit for Option<T> {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        match self {
+            None => (),
+            Some(x) => x.visit(table, clause),
+        }
+    }
+}
+
+impl<T: TableFilterVisit> TableFilterVisit for Box<T> {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        (**self).visit(table, clause)
+    }
+}
+
+impl<T: TableFilterVisit> TableFilterVisit for Vec<T> {
+    fn visit(&mut self, table: &Vec<String>, clause: &Expr) -> () {
+        for x in self.iter_mut() {
+            x.visit(table, clause)
+        }
+    }
+}

--- a/native/jumpwire_proxy_sql_parser/src/matcher.rs
+++ b/native/jumpwire_proxy_sql_parser/src/matcher.rs
@@ -1,0 +1,3 @@
+mod table;
+
+pub use self::table::TableMatch;

--- a/native/jumpwire_proxy_sql_parser/src/matcher/table.rs
+++ b/native/jumpwire_proxy_sql_parser/src/matcher/table.rs
@@ -1,0 +1,61 @@
+use sqlparser::ast::*;
+
+/// Trait for matching against a table name
+pub trait TableMatch<Rhs>
+where
+    Rhs: ?Sized,
+{
+    fn matches(&self, other: &Rhs) -> bool;
+}
+
+impl TableMatch<Vec<String>> for TableFactor {
+    fn matches(&self, other: &Vec<String>) -> bool {
+        match self {
+            TableFactor::Table { name, .. } => name.matches(other),
+            TableFactor::NestedJoin {
+                table_with_joins, ..
+            } => table_with_joins.matches(other),
+            _ => false,
+        }
+    }
+}
+
+impl TableMatch<Vec<String>> for TableWithJoins {
+    fn matches(&self, other: &Vec<String>) -> bool {
+        self.relation.matches(other) || self.joins.iter().any(|join| join.relation.matches(other))
+    }
+}
+
+impl TableMatch<Vec<String>> for ObjectName {
+    fn matches(&self, other: &Vec<String>) -> bool {
+        self.0.matches(other)
+    }
+}
+
+impl TableMatch<Vec<String>> for Select {
+    fn matches(&self, other: &Vec<String>) -> bool {
+        self.from.matches(other)
+    }
+}
+
+impl TableMatch<Vec<String>> for Vec<Ident> {
+    fn matches(&self, other: &Vec<String>) -> bool {
+        let ident: Vec<String> = self.iter().map(|i| i.value.to_lowercase()).collect();
+        ident == *other
+    }
+}
+
+impl<T: TableMatch<Vec<String>>> TableMatch<Vec<String>> for Vec<T> {
+    fn matches(&self, other: &Vec<String>) -> bool {
+        self.iter().any(|x| x.matches(other))
+    }
+}
+
+impl<T: TableMatch<Vec<String>>> TableMatch<Vec<String>> for Option<T> {
+    fn matches(&self, other: &Vec<String>) -> bool {
+        match self {
+            None => false,
+            Some(x) => x.matches(other),
+        }
+    }
+}

--- a/test/jumpwire/proxy/postgres_test.exs
+++ b/test/jumpwire/proxy/postgres_test.exs
@@ -861,7 +861,9 @@ defmodule JumpWire.Proxy.PostgresTest do
     on_exit fn -> JumpWire.GlobalConfig.delete(:policies, key) end
     JumpWire.GlobalConfig.put(:policies, key, policy)
 
-    params = Keyword.put(params, :parameters, [jw_id: value])
+    params = Keyword.update!(params, :username, fn username ->
+      "#{username}##{value}"
+    end)
     {:ok, pid} = Postgrex.start_link(params)
     assert {:ok, %{rows: [row]}} = Postgrex.query(pid, "SELECT value, phone FROM #{table}", [])
     assert Enum.member?(rows, row)


### PR DESCRIPTION
This implementation has a few notable limitations:

- The policy requires a string for the value of the where clause
- No validation is done on the policy key/value
- Table matching is limited, it doesn't take namespaces into account

The recursion in the rust module should cover all possible cases of nested table access. I'm definitely happy to add more test cases if you think of any that would be useful.